### PR TITLE
do not delete Dockerfile if present in the root of a sample-app

### DIFF
--- a/generate_projects.sh
+++ b/generate_projects.sh
@@ -6,7 +6,7 @@ echo "---------------------------------------------"
 echo "current project: jhipster-sample-app"
 echo "---------------------------------------------"
 cd jhipster-sample-app
-find . -not -name ".yo-rc.json" -type f -maxdepth 1 -delete
+find . -not -name ".yo-rc.json" -not -name "Dockerfile" -type f -maxdepth 1 -delete
 rm .git/index
 rm -rf src
 rm -rf node_modules
@@ -20,7 +20,7 @@ echo "---------------------------------------------"
 echo "current project: jhipster-sample-app-ng1"
 echo "---------------------------------------------"
 cd jhipster-sample-app-ng1
-find . -not -name ".yo-rc.json" -type f -maxdepth 1 -delete
+find . -not -name ".yo-rc.json" -not -name "Dockerfile" -type f -maxdepth 1 -delete
 rm .git/index
 rm -rf src
 rm -rf node_modules
@@ -34,7 +34,7 @@ echo "---------------------------------------------"
 echo "current project: jhipster-sample-app-react"
 echo "---------------------------------------------"
 cd jhipster-sample-app-react
-find . -not -name ".yo-rc.json" -type f -maxdepth 1 -delete
+find . -not -name ".yo-rc.json" -not -name "Dockerfile" -type f -maxdepth 1 -delete
 rm .git/index
 rm -rf src
 rm -rf node_modules
@@ -48,7 +48,7 @@ echo "---------------------------------------------"
 echo "current project: jhipster-sample-app-gradle"
 echo "---------------------------------------------"
 cd jhipster-sample-app-gradle
-find . -not -name ".yo-rc.json" -type f -maxdepth 1 -delete
+find . -not -name ".yo-rc.json" -not -name "Dockerfile" -type f -maxdepth 1 -delete
 rm .git/index
 rm -rf src
 rm -rf node_modules
@@ -62,7 +62,7 @@ echo "---------------------------------------------"
 echo "current project: jhipster-sample-app-mongodb"
 echo "---------------------------------------------"
 cd jhipster-sample-app-mongodb
-find . -not -name ".yo-rc.json" -type f -maxdepth 1 -delete
+find . -not -name ".yo-rc.json" -not -name "Dockerfile" -type f -maxdepth 1 -delete
 rm .git/index
 rm -rf src
 rm -rf node_modules
@@ -76,7 +76,7 @@ echo "---------------------------------------------"
 echo "current project: jhipster-sample-app-cassandra"
 echo "---------------------------------------------"
 cd jhipster-sample-app-cassandra
-find . -not -name ".yo-rc.json" -type f -maxdepth 1 -delete
+find . -not -name ".yo-rc.json" -not -name "Dockerfile" -type f -maxdepth 1 -delete
 rm .git/index
 rm -rf src
 rm -rf node_modules
@@ -90,7 +90,7 @@ echo "---------------------------------------------"
 echo "current project: jhipster-sample-app-dto"
 echo "---------------------------------------------"
 cd jhipster-sample-app-dto
-find . -not -name ".yo-rc.json" -type f -maxdepth 1 -delete
+find . -not -name ".yo-rc.json" -not -name "Dockerfile" -type f -maxdepth 1 -delete
 rm .git/index
 rm -rf src
 rm -rf node_modules
@@ -104,7 +104,7 @@ echo "---------------------------------------------"
 echo "current project: jhipster-sample-app-elasticsearch"
 echo "---------------------------------------------"
 cd jhipster-sample-app-elasticsearch
-find . -not -name ".yo-rc.json" -type f -maxdepth 1 -delete
+find . -not -name ".yo-rc.json" -not -name "Dockerfile" -type f -maxdepth 1 -delete
 rm .git/index
 rm -rf src
 rm -rf node_modules
@@ -118,7 +118,7 @@ echo "---------------------------------------------"
 echo "current project: jhipster-sample-app-hazelcast"
 echo "---------------------------------------------"
 cd jhipster-sample-app-hazelcast
-find . -not -name ".yo-rc.json" -type f -maxdepth 1 -delete
+find . -not -name ".yo-rc.json" -not -name "Dockerfile" -type f -maxdepth 1 -delete
 rm .git/index
 rm -rf src
 rm -rf node_modules
@@ -132,7 +132,7 @@ echo "---------------------------------------------"
 echo "current project: jhipster-sample-app-nocache"
 echo "---------------------------------------------"
 cd jhipster-sample-app-nocache
-find . -not -name ".yo-rc.json" -type f -maxdepth 1 -delete
+find . -not -name ".yo-rc.json" -not -name "Dockerfile" -type f -maxdepth 1 -delete
 rm .git/index
 rm -rf src
 rm -rf node_modules
@@ -146,7 +146,7 @@ echo "---------------------------------------------"
 echo "current project: jhipster-sample-app-noi18n"
 echo "---------------------------------------------"
 cd jhipster-sample-app-noi18n
-find . -not -name ".yo-rc.json" -type f -maxdepth 1 -delete
+find . -not -name ".yo-rc.json" -not -name "Dockerfile" -type f -maxdepth 1 -delete
 rm .git/index
 rm -rf src
 rm -rf node_modules
@@ -160,7 +160,7 @@ echo "---------------------------------------------"
 echo "current project: jhipster-sample-app-websocket"
 echo "---------------------------------------------"
 cd jhipster-sample-app-websocket
-find . -not -name ".yo-rc.json" -type f -maxdepth 1 -delete
+find . -not -name ".yo-rc.json" -not -name "Dockerfile" -type f -maxdepth 1 -delete
 rm .git/index
 rm -rf src
 rm -rf node_modules
@@ -174,7 +174,7 @@ echo "---------------------------------------------"
 echo "current project: jhipster-sample-app-oauth2"
 echo "---------------------------------------------"
 cd jhipster-sample-app-oauth2
-find . -not -name ".yo-rc.json" -type f -maxdepth 1 -delete
+find . -not -name ".yo-rc.json" -not -name "Dockerfile" -type f -maxdepth 1 -delete
 rm .git/index
 rm -rf src
 rm -rf node_modules
@@ -188,7 +188,7 @@ echo "---------------------------------------------"
 echo "current project: jhipster-sample-app-token"
 echo "---------------------------------------------"
 cd jhipster-sample-app-token
-find . -not -name ".yo-rc.json" -type f -maxdepth 1 -delete
+find . -not -name ".yo-rc.json" -not -name "Dockerfile" -type f -maxdepth 1 -delete
 rm .git/index
 rm -rf src
 rm -rf node_modules
@@ -202,7 +202,7 @@ echo "---------------------------------------------"
 echo "current project: jhipster-sample-app-gateway"
 echo "---------------------------------------------"
 cd jhipster-sample-app-gateway
-find . -not -name ".yo-rc.json" -type f -maxdepth 1 -delete
+find . -not -name ".yo-rc.json" -not -name "Dockerfile" -type f -maxdepth 1 -delete
 rm .git/index
 rm -rf src
 rm -rf node_modules
@@ -216,7 +216,7 @@ echo "---------------------------------------------"
 echo "current project: jhipster-sample-app-microservice"
 echo "---------------------------------------------"
 cd jhipster-sample-app-microservice
-find . -not -name ".yo-rc.json" -type f -maxdepth 1 -delete
+find . -not -name ".yo-rc.json" -not -name "Dockerfile" -type f -maxdepth 1 -delete
 rm .git/index
 rm -rf src
 rm -rf node_modules


### PR DESCRIPTION
This PR skips deleting Dockerfile if present in the root directory of a sample app.  I added it to all commands in case we decide to add more automated sample apps (such as React)

Fix jhipster/generator-jhipster#6853